### PR TITLE
fix: html anchors are case sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 * [Shell](#shell)
 * [Swift](#swift)
 * [TeX](#tex)
-* [TypeScript](#typeScript)
+* [TypeScript](#typescript)
 * [Vim script](#vim-script)
 ## Most Stars
 


### PR DESCRIPTION
Currently, https://evanli.github.io/Github-Ranking/#typeScript fails to jump to the TypeScript section due to case-mismatch.